### PR TITLE
Fix path to the plist

### DIFF
--- a/schedule-jobs-launchd.md
+++ b/schedule-jobs-launchd.md
@@ -94,7 +94,7 @@ Now you need to load your agent and start it.
 # Load and start your new agent
 
 ## With the built in `launchctl`
-$ launchctl load ~/Library/org.yourusername.email-mom.plist
+$ launchctl load ~/Library/LaunchAgents/org.yourusername.email-mom.plist
 $ launchctl start org.yourusername.email-mom
 
 ## Or with Lunchy


### PR DESCRIPTION
As per the instructions, the new job description is stored in ~/Library/LaunchAgents/